### PR TITLE
Return meaningful error msg upon invalid spec

### DIFF
--- a/src/controllers/workflow.js
+++ b/src/controllers/workflow.js
@@ -40,7 +40,7 @@ const saveWorkflow = async (ctx, next) => {
     await next();
   } catch (err) {
     ctx.status = 400;
-    ctx.body = { error: err };
+    ctx.body = { message: `Failed at ${err.message}`, error: err };
     await next();
   }
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

If someone sends an invalid json spec to create a workflow in the server, the response is always a generic

```json
{
    "error": {
        "generatedMessage": false,
        "name": "AssertionError [ERR_ASSERTION]",
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "==",
    }
}
```

What is changed is a new field ```message``` in the response, with the description of the error

```json
{
    "message": "Failed at node 1: parameters_has_input_schema",
    "error": {
        "generatedMessage": false,
        "name": "AssertionError [ERR_ASSERTION]",
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "==",
    }
}
```

**Does this PR introduce a user-facing change?**:

None
